### PR TITLE
Fixes #1: Add Dead Zone Variable; Default to 60

### DIFF
--- a/MiniFork_Bluepad2.0/MiniFork_Bluepad2.0.ino
+++ b/MiniFork_Bluepad2.0/MiniFork_Bluepad2.0.ino
@@ -106,7 +106,8 @@ void processGamepad(ControllerPtr ctl) {
 
 void processThrottle(int axisYValue) {
   float adjustedThrottleValue = axisYValue / 2;
-  if (adjustedThrottleValue > 15 || adjustedThrottleValue < -15) {
+  int deadZoneValue = 60;
+  if (adjustedThrottleValue > deadZoneValue || adjustedThrottleValue < -deadZoneValue) {
     if (hardRight) {
       moveMotor(rightMotor0, rightMotor1, -1 * (adjustedThrottleValue * steeringAdjustment));
     } else if (hardLeft) {

--- a/MiniFork_PS3_Controller/MiniFork_PS3_Controller.ino
+++ b/MiniFork_PS3_Controller/MiniFork_PS3_Controller.ino
@@ -167,7 +167,8 @@ void notify() {
 }
 void processThrottle(int throttleValue) {
   adjustedThrottleValue = throttleValue;
-  if (adjustedThrottleValue > 15 || adjustedThrottleValue < -15) {
+  int deadZoneValue = 60;
+  if (adjustedThrottleValue > deadZoneValue || adjustedThrottleValue < -deadZoneValue) {
     if (hardRight) {
       moveMotor(rightMotor0, rightMotor1, -1 * (adjustedThrottleValue * steeringAdjustment));
     } else if (hardLeft) {


### PR DESCRIPTION
This change adds a deadZoneValue variable and defaults this to 60. This prevents the motor from emitting a high pitched whine when unable to move the forklift. 

60 seemed to balance full motor response, without the whine occurring without movement. 

This was tested and verified using 12v 100RPM N20 motors and paired with an Xbox Elite 2 controller. 